### PR TITLE
Fix/contributor cards duplicate info issue #55

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -1,0 +1,75 @@
+# Fix: Contributor Cards Duplicate Info Issue
+
+## Problem
+The contributor cards were showing the same user info (name, bio, GitHub link) repeatedly for each component, making it messy and hard to read with more contributors.
+
+## Root Cause
+1. **Data Overriding**: The `updateCardWithGithubData` function was overriding original contributor data from JSON with GitHub API data
+2. **Duplicate Entries**: The contributors.json file contained duplicate GitHub profile URLs
+3. **Limited Search**: Search functionality only worked on usernames
+4. **Visual Sameness**: All cards looked identical without visual variety
+
+## Solutions Implemented
+
+### 1. Preserve Original Data ✅
+- Modified `updateCardWithGithubData()` to **preserve** original contributor names and bios from JSON
+- Only update GitHub-specific data (avatar, stats) while keeping contributor-provided information
+- Store original data in `dataset` attributes for reference
+
+### 2. Duplicate Detection & Filtering ✅
+- Added `filterAndValidateContributors()` function to remove duplicate entries
+- Track seen GitHub usernames to prevent duplicate cards
+- Validate required fields (name, bio, github_profile_url) before display
+- Log duplicate removal for debugging
+
+### 3. Enhanced Bio Information ✅
+- Include occupation and place information in bio display
+- Format as: `bio • occupation • place` for richer content
+- Better utilization of available contributor data
+
+### 4. Improved Search Functionality ✅
+- Search now includes username, name, AND bio content
+- More comprehensive filtering for better user experience
+- Search across all contributor-provided information
+
+### 5. Visual Card Variety ✅
+- Added alternating border styles for visual distinction
+- Gradient border effects using CSS pseudo-elements
+- Bio separator lines with accent color
+- Better spacing and typography
+
+### 6. Error Handling ✅
+- Graceful handling of failed GitHub API calls
+- Preserve original data when API requests fail
+- Show "N/A" for stats instead of error messages
+- Comprehensive logging for debugging
+
+## Technical Changes
+
+### JavaScript (js/main.js)
+- `filterAndValidateContributors()`: New function for data validation
+- `createPlaceholderCard()`: Enhanced with occupation/place data
+- `updateCardWithGithubData()`: Preserves original contributor data
+- `filterContributors()`: Improved search across multiple fields
+
+### CSS (css/style.css)
+- Added gradient border effects for card variety
+- Improved bio display with visual separators
+- Fixed CSS linting issues (line-clamp compatibility)
+- Enhanced visual hierarchy and spacing
+
+## Results
+- ✅ Each contributor card now displays unique, accurate information
+- ✅ No more duplicate or overwritten contributor data
+- ✅ Better visual distinction between cards
+- ✅ Enhanced search functionality
+- ✅ Preserved contributor-provided information
+- ✅ Improved readability and user experience
+
+## Testing
+The changes have been tested to ensure:
+- Duplicate contributors are filtered out
+- Original contributor data is preserved
+- GitHub API data enhances but doesn't override
+- Search works across multiple fields
+- Visual improvements enhance readability

--- a/css/style.css
+++ b/css/style.css
@@ -175,6 +175,29 @@ main {
     gap: 24px;
     opacity: 0;
     animation: card-appear 0.5s ease-out forwards;
+    position: relative;
+}
+
+/* Add subtle gradient border for variety */
+.contributor-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    padding: 1px;
+    background: linear-gradient(135deg, #444c56, #30363d, #21262d);
+    border-radius: 20px;
+    mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    mask-composite: exclude;
+    pointer-events: none;
+}
+
+/* Alternate card styling for visual variety */
+.contributor-card:nth-child(even) {
+    border-color: #30363d;
+}
+
+.contributor-card:nth-child(even)::before {
+    background: linear-gradient(135deg, #30363d, #262c32, #1f252a);
 }
 
 .contributor-card:hover {
@@ -221,9 +244,22 @@ main {
     line-height: 1.6;
     display: -webkit-box;
     -webkit-line-clamp: 2;
+    line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
     flex-grow: 1;
+    margin-bottom: 4px;
+}
+
+/* Add visual separator for better bio readability */
+.card-content .bio::after {
+    content: '';
+    display: block;
+    width: 30px;
+    height: 2px;
+    background: linear-gradient(90deg, var(--accent-green), transparent);
+    margin-top: 8px;
+    border-radius: 1px;
 }
 
 .card-content .stats {
@@ -347,6 +383,7 @@ footer {
         flex-grow: 0;
         margin-bottom: 20px;
         -webkit-line-clamp: 3;
+        line-clamp: 3;
     }
     .card-content .stats {
         justify-content: space-around;


### PR DESCRIPTION
fixed issue #55 
🐛 Fix: Contributor Cards Showing Duplicate User Information
Issue
Contributor cards were displaying repetitive user information, making the showcase difficult to read and navigate with multiple contributors.

Changes Made
Fixed data overriding: Preserve original contributor names/bios from JSON instead of replacing with GitHub API data
Added duplicate filtering: Remove duplicate contributors based on GitHub username
Enhanced information display: Include occupation and location in bio formatting
Improved search: Search across username, name, and bio content
Visual enhancements: Added alternating card styles and gradient borders for better distinction
Better error handling: Graceful API failure handling with preserved original data