### PR TITLE
Fix: prevent duplicate contributor cards + CI check

### DIFF
--- a/.github/scripts/validate_contributors.js
+++ b/.github/scripts/validate_contributors.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const CONTRIBUTORS_PATH = path.join(__dirname, '..', '..', 'contributors.json');
+
+function normalizeGithubUsername(urlOrValue) {
+  if (!urlOrValue || typeof urlOrValue !== 'string') return null;
+  let str = urlOrValue.trim();
+  if (!str) return null;
+  // If they provided a raw username (e.g. "@user" or "user")
+  if (!str.includes('github.com')) {
+    return str.replace(/^@/, '').replace(/\/+$/, '').toLowerCase();
+  }
+  try {
+    const u = new URL(str, 'https://github.com');
+    const parts = u.pathname.split('/').filter(Boolean);
+    if (parts.length === 0) return null;
+    return parts[parts.length - 1].toLowerCase();
+  } catch (e) {
+    const parts = str.split('/').filter(Boolean);
+    return parts.length ? parts[parts.length - 1].toLowerCase() : null;
+  }
+}
+
+function loadContributors(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    console.error('Error reading or parsing contributors.json:', err.message);
+    process.exit(2);
+  }
+}
+
+function findDuplicates(contributors) {
+  const map = new Map();
+  const duplicates = new Map();
+
+  contributors.forEach((c, idx) => {
+    const username = normalizeGithubUsername(c.github_profile_url || c.github || c.github_profile || c.github_url || '');
+    const key = username || `__fallback_${idx}`;
+    if (!map.has(key)) {
+      map.set(key, [idx]);
+    } else {
+      map.get(key).push(idx);
+      duplicates.set(key, map.get(key));
+    }
+  });
+
+  return duplicates;
+}
+
+function main() {
+  const contributors = loadContributors(CONTRIBUTORS_PATH);
+  if (!Array.isArray(contributors)) {
+    console.error('contributors.json should contain a JSON array of contributor objects.');
+    process.exit(2);
+  }
+
+  const duplicates = findDuplicates(contributors);
+  if (duplicates.size === 0) {
+    console.log('No duplicate contributors found.');
+    process.exit(0);
+  }
+
+  console.error('\nDuplicate contributors detected!\n');
+  for (const [key, indexes] of duplicates.entries()) {
+    console.error(`- username/key: ${key} -> ${indexes.length} entries (indexes: ${indexes.join(', ')})`);
+    indexes.forEach((i) => {
+      const item = contributors[i];
+      console.error(`  index ${i}: name="${item.name || ''}" github_profile_url="${item.github_profile_url || ''}" project_netlify_link="${item.project_netlify_link || ''}"`);
+    });
+    console.error('');
+  }
+
+  console.error('Please remove or merge duplicate entries in contributors.json before merging this PR.');
+  process.exit(1);
+}
+
+main();

--- a/.github/workflows/validate-contributors.yml
+++ b/.github/workflows/validate-contributors.yml
@@ -1,0 +1,31 @@
+name: Validate contributors.json
+
+on:
+  pull_request:
+    paths:
+      - 'contributors.json'
+      - '.github/scripts/validate_contributors.js'
+  push:
+    paths:
+      - 'contributors.json'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: |
+          # no external dependencies; make script executable
+          ls -la .github/scripts || true
+
+      - name: Run contributors.json validator
+        run: |
+          node .github/scripts/validate_contributors.js


### PR DESCRIPTION
# Summary

This PR prevents duplicate contributor cards from appearing on the Contributors page and adds a CI validator to block duplicate contributor entries in `contributors.json`.

## Changes

- **feat:** Add load-time normalization and deduplication in `main.js`

  1. Normalizes GitHub usernames and deduplicates contributors at page load.
  2. Aggregates multiple `project_netlify_link` values into a `projects` array on the consolidated contributor object.
  3. Adds a render-time guard to ensure each normalized username is rendered only once.
  4. Preserves existing behavior for entries without a GitHub URL.

- **ci:** Add `contributors.json` validator

  1. `/.github/scripts/validate_contributors.js` — Node script that scans `contributors.json`, normalizes usernames, and fails with details if duplicates are found.
  2. `/.github/workflows/validate-contributors.yml` — GitHub Actions workflow that runs the validator on `pull_request` (when `contributors.json` changes) and on push.

## Rationale

- Duplicates in `contributors.json` caused multiple cards to render for the same user. This is confusing for visitors and produces redundant API calls.
- The validator provides repository-level enforcement to prevent duplicate entries from being merged.
- The frontend deduplication ensures previews and existing data don't show duplicate cards even if duplicates exist temporarily (e.g., in PRs or forks).
